### PR TITLE
renamed nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_IS_NULL

### DIFF
--- a/src/chrome/content/mboximport/mboximport.js
+++ b/src/chrome/content/mboximport/mboximport.js
@@ -1327,14 +1327,19 @@ function trytoimportEML(file, msgFolder, removeFile, fileArray, allEML) {
 			.getService(Ci.nsIIOService);
 		var fileURI = ios.newFileURI(file);
 		var channel;
-
+		let varNsILoadInfo;
+		if (versionChecker.compare(currentVersion, "80") >= 0) {
+			varNsILoadInfo = Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_SEC_CONTEXT_IS_NULL;
+		} else {
+			varNsILoadInfo = Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_IS_NULL;
+		}
 		if (Services.io.newChannelFromURI2) {
 			channel = Services.io.newChannelFromURI2(
 				fileURI,
 				null,
 				Services.scriptSecurityManager.getSystemPrincipal(),
 				null,
-				Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_IS_NULL,
+				varNsILoadInfo,
 				Ci.nsIContentPolicy.TYPE_OTHER
 			);
 		} else {
@@ -1343,7 +1348,7 @@ function trytoimportEML(file, msgFolder, removeFile, fileArray, allEML) {
 				null,
 				Services.scriptSecurityManager.getSystemPrincipal(),
 				null,
-				Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_IS_NULL,
+				varNsILoadInfo,
 				Ci.nsIContentPolicy.TYPE_OTHER
 			);
 		}


### PR DESCRIPTION
In Thunderbird 80 nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_IS_NULL was renamed to SEC_ALLOW_CROSS_ORIGIN_SEC_CONTEXT_IS_NULL, which affects the import of eml messages. 
I added new variable varNsILoadInfo. Now importing from the eml file works.