### PR TITLE
Re-enables delay in 91 startup and fix race condition in WL API

### DIFF
--- a/src/api/SessionRestore/schema.json
+++ b/src/api/SessionRestore/schema.json
@@ -13,6 +13,7 @@
       {
         "name": "isRestored",
         "type": "function",
+        "async": true,
         "parameters": []
       }
     ]    

--- a/src/api/WindowListener/README.md
+++ b/src/api/WindowListener/README.md
@@ -1,0 +1,1 @@
+Usage description can be found in the [wiki](https://github.com/thundernest/addon-developer-support/wiki/Using-the-WindowListener-API-to-convert-a-Legacy-Overlay-WebExtension-into-a-MailExtension-for-Thunderbird-78).

--- a/src/api/WindowListener/changelog.md
+++ b/src/api/WindowListener/changelog.md
@@ -1,3 +1,7 @@
+Version: 1.57
+-------------
+- fix race condition which could prevent the AOM tab to be monkey patched correctly
+
 Version: 1.56
 -------------
 - be precise on which revision the wrench symbol should be displayed, instead of

--- a/src/api/WindowListener/implementation.js
+++ b/src/api/WindowListener/implementation.js
@@ -200,7 +200,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
   // returns the outer browser, not the nested browser of the add-on manager
   // events must be attached to the outer browser
   getAddonManagerFromTab(tab) {
-    if (tab.browser) {
+    if (tab.browser && tab.mode.name == "contentTab") {
       let win = tab.browser.contentWindow;
       if (win && win.location.href == "about:addons") {
         return win;
@@ -211,9 +211,28 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
   getAddonManagerFromWindow(window) {
     let tabMail = this.getTabMail(window);
     for (let tab of tabMail.tabInfo) {
-      let win = this.getAddonManagerFromTab(tab);
-      if (win) {
-        return win;
+      let managerWindow = this.getAddonManagerFromTab(tab);
+      if (managerWindow) {
+        return managerWindow;
+      }
+    }
+  }
+
+  async getAddonManagerFromWindowWaitForLoad(window) {
+    let { setTimeout } = Services.wm.getMostRecentWindow("mail:3pane");
+    
+    let tabMail = this.getTabMail(window);
+    for (let tab of tabMail.tabInfo) {
+      if (tab.browser && tab.mode.name == "contentTab") {
+        // Instead of registering a load observer, wait until its loaded. Not nice,
+        // but gets aroud a lot of edge cases.
+        while(!tab.pageLoaded) {
+          await new Promise(r => setTimeout(r, 150));
+        }
+        let managerWindow = this.getAddonManagerFromTab(tab);
+        if (managerWindow) {
+          return managerWindow;
+        }
       }
     }
   }
@@ -329,41 +348,20 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
 
     // TabMonitor to detect opening of tabs, to setup the options button in the add-on manager.
     this.tabMonitor = {
-      onTabTitleChanged(aTab) { },
-      onTabClosing(aTab) { },
-      onTabPersist(aTab) { },
-      onTabRestored(aTab) { },
-      onTabSwitched(aNewTab, aOldTab) {
-        //self.setupAddonManager(self.getAddonManagerFromTab(aNewTab));
-      },
-      async onTabOpened(aTab) {
-        if (aTab.browser) {
-          if (!aTab.pageLoaded) {
-            // await a location change if browser is not loaded yet
-            await new Promise((resolve) => {
-              let reporterListener = {
-                QueryInterface: ChromeUtils.generateQI([
-                  "nsIWebProgressListener",
-                  "nsISupportsWeakReference",
-                ]),
-                onStateChange() { },
-                onProgressChange() { },
-                onLocationChange(
-                  /* in nsIWebProgress*/ aWebProgress,
-                  /* in nsIRequest*/ aRequest,
-                  /* in nsIURI*/ aLocation
-                ) {
-                  aTab.browser.removeProgressListener(reporterListener);
-                  resolve();
-                },
-                onStatusChange() { },
-                onSecurityChange() { },
-                onContentBlockingEvent() { },
-              };
-              aTab.browser.addProgressListener(reporterListener);
-            });
+      onTabTitleChanged(tab) { },
+      onTabClosing(tab) { },
+      onTabPersist(tab) { },
+      onTabRestored(tab) { },
+      onTabSwitched(aNewTab, aOldTab) { },
+      async onTabOpened(tab) {
+        if (tab.browser && tab.mode.name == "contentTab") {
+          let { setTimeout } = Services.wm.getMostRecentWindow("mail:3pane");
+          // Instead of registering a load observer, wait until its loaded. Not nice,
+          // but gets aroud a lot of edge cases.
+          while(!tab.pageLoaded) {
+            await new Promise(r => setTimeout(r, 150));
           }
-          self.setupAddonManager(self.getAddonManagerFromTab(aTab));
+          self.setupAddonManager(self.getAddonManagerFromTab(tab));
         }
       },
     };
@@ -594,16 +592,14 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
                           self
                         );
                       } else {
-                        // Setup the options button/menu in the add-on manager, if it is already open.
-                        self.setupAddonManager(
-                          self.getAddonManagerFromWindow(window),
-                          true
-                        );
                         // Add a tabmonitor, to be able to setup the options button/menu in the add-on manager.
                         self
                           .getTabMail(window)
                           .registerTabMonitor(self.tabMonitor);
                         window[self.uniqueRandomID].hasTabMonitor = true;
+                        // Setup the options button/menu in the add-on manager, if it is already open.
+                        let managerWindow = await self.getAddonManagerFromWindowWaitForLoad(window);
+                        self.setupAddonManager(managerWindow, true);
                       }
                     }
                   }

--- a/src/api/WindowListener/implementation.js
+++ b/src/api/WindowListener/implementation.js
@@ -2,7 +2,7 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
- * Version: 1.56
+ * Version: 1.57
  *
  * Author: John Bieling (john@thunderbird.net)
  *

--- a/src/background.js
+++ b/src/background.js
@@ -9,16 +9,15 @@ console.debug('background start', majorVersion);
 let startupDelay;
 if (majorVersion.major < 92) {
 	startupDelay = await new Promise(async (resolve) => {
+		const restoreListener = (window, state = true) => {
+			browser.SessionRestore.onStartupSessionRestore.removeListener(restoreListener);
+			resolve(state);
+		}
+		browser.SessionRestore.onStartupSessionRestore.addListener(restoreListener);
+
 		let isRestored = await browser.SessionRestore.isRestored();
-		console.log("session is restored:", isRestored);
 		if (isRestored) {
-			resolve(false);
-		} else {
-			const listener = () => {
-				browser.SessionRestore.onStartupSessionRestore.removeListener(listener);
-				resolve(true);
-			}
-			browser.SessionRestore.onStartupSessionRestore.addListener(listener);
+			restoreListener(null, false);
 		}
 	});
 }

--- a/src/background.js
+++ b/src/background.js
@@ -2,23 +2,31 @@
 
 var majorVersion = await getThunderbirdVersion();
 
-console.debug('background Start', majorVersion);
+console.debug('background start', majorVersion);
 
 // must delay startup for #274 using SessionRestore for 91, 102
 // does this by default 
-let isRestored = await browser.SessionRestore.isRestored();
-if (isRestored && majorVersion.major < 92) {
-	await new Promise(resolve => {
-		const listener = () => {
-			browser.SessionRestore.onStartupSessionRestore.removeListener(listener);
-			resolve();
+let startupDelay;
+if (majorVersion.major < 92) {
+	startupDelay = await new Promise(async (resolve) => {
+		let isRestored = await browser.SessionRestore.isRestored();
+		console.log("session is restored:", isRestored);
+		if (isRestored) {
+			resolve(false);
+		} else {
+			const listener = () => {
+				browser.SessionRestore.onStartupSessionRestore.removeListener(listener);
+				resolve(true);
+			}
+			browser.SessionRestore.onStartupSessionRestore.addListener(listener);
 		}
-		browser.SessionRestore.onStartupSessionRestore.addListener(listener);
 	});
 }
+// Tri-state, true, false, undefined.
+console.debug('delay background start', startupDelay);
 
-console.debug('delay background Start');
 main();
+
 
 async function getThunderbirdVersion() {
 	let browserInfo = await messenger.runtime.getBrowserInfo();


### PR DESCRIPTION
The `isRestore` function was not defined `async` and therefore never returned a `bool` but always `undefined`. Sorry. So the delay code was never executed.

After that is fixed, there is a race condition: `isRestored` could be `false`, but since it is a `Promise`, the main thread may not return in time before the event is emitted and miss it. Registering the listener before checking if it is already restored fixed that.

After that, there was still a race condition inside the WL: When TB started and restored an AOM tab, that tab was not monkey patched. Closing and reopening the AOM tab, correctly inserted the wrench again. But why does an additional delay during startup cause this? Without the delay, the WL code skipped monkey patching the AOM, because the tab was not yet ready. Instead, its tab listener fired once the tab became ready, and it got monkey patched. With the extra delay, we moved into a dead zone: The window had fired its tab event for the restored tab already, so the "is already open" code should trigger, but it still skipped, because even though the tab was there, it was not loaded. Only the tab listener waited for the final load, the "is already open" code assumed the tab is fully loaded.

I updated the WL API. It works for me now in all scenarios. Can you confirm?