### PR TITLE
Update importexport-help.css

### DIFF
--- a/src/chrome/content/mboximport/help/importexport-help.css
+++ b/src/chrome/content/mboximport/help/importexport-help.css
@@ -7,7 +7,7 @@
 	--list-highlight-text-color: black;
 	--in-content-button-background: rgba(207, 207, 216, 0.33);
 	--list-disabled-font-color: #cccccc;
-	--table-border-color: black;
+	--table-border-color: #d2d2d2;
 	--table-stripe-even: #e8e8e8;
 	--link-color: darkblue;
 }
@@ -83,7 +83,7 @@ table.menu-table .submenu3 {
 }
 
 table.dateformat-table {
-	border: 1px solid black;
+	border: 1px solid var(--table-border-color);
 	border-collapse: collapse;
 	width: 90%;
 	margin-left: 30px;
@@ -93,19 +93,19 @@ table.dateformat-table {
 table.dateformat-table tr,
 table.dateformat-table td,
 table.dateformat-table th {
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--table-border-color);
 	border-collapse: collapse;
 	padding: 6px;
-	padding-right: 25px;
+	/*padding-right: 25px;*/
 }
 
 table.dateformat-table tr td:first-child {
-	padding-left: 30px;
+	/*padding-left: 30px;*/
+	text-align: center;
 }
 
-
 table.dateformat-table tr:nth-child(even) {
-	background-color: #f2f2f2;
+	background-color: var(--table-stripe-even);
 }
 
 table.dateformat-table thead {
@@ -115,7 +115,7 @@ table.dateformat-table thead {
 
 
 table.token-table {
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--table-border-color);
 	border-collapse: collapse;
 	margin-left: 30px;
 	margin-right: 30px;
@@ -124,14 +124,14 @@ table.token-table {
 table.token-table tr,
 table.token-table td,
 table.token-table th {
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--table-border-color);
 	border-collapse: collapse;
 	padding: 6px;
-	padding-right: 25px;
+	/*padding-right: 25px;*/
 }
 
-table.token-table tr:nth-child(odd) {
-	background-color: #f2f2f2;
+table.token-table tr:nth-child(even) {
+	background-color: var(--table-stripe-even);
 }
 
 table.token-table tr:nth-child(1) {


### PR DESCRIPTION
Suggested changes to the help css for better rendering (in my opinion), including removal of the white rows in some tables in dark mode.